### PR TITLE
SCRUM-28: refactor views; keep WPF conventions

### DIFF
--- a/OmniMouse/MainWindow.xaml
+++ b/OmniMouse/MainWindow.xaml
@@ -1,30 +1,12 @@
 ﻿<Window x:Class="OmniMouse.MainWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        Title="OmniMouse Input Monitor" Height="500" Width="800">
-    <DockPanel>
-        <StackPanel Orientation="Horizontal" Margin="10" DockPanel.Dock="Top">
-            <Button Name="HostButton" Content="Host" Width="100" Margin="0,0,10,0" Click="HostButton_Click"/>
-            <Button Name="CohostButton" Content="Cohost" Width="100" Margin="0,0,10,0" Click="CohostButton_Click"/>
-            <Button Name="DisconnectButton" Content="Disconnect" Width="120" Margin="0,0,10,0" Click="DisconnectButton_Click"/>
-            <TextBox Name="HostIpBox" Width="200" Margin="0,0,10,0" VerticalAlignment="Center" ToolTip="Enter host IP for cohost mode"/>
-        </StackPanel>
-        <TextBlock Text="OmniMouse Input/Output Log"
-                   FontWeight="Bold"
-                   FontSize="18"
-                   Margin="10"
-                   DockPanel.Dock="Top"/>
-        <TextBox Name="ConsoleOutputBox"
-                 VerticalScrollBarVisibility="Auto"
-                 HorizontalScrollBarVisibility="Auto"
-                 IsReadOnly="True"
-                 TextWrapping="Wrap"
-                 AcceptsReturn="True"
-                 FontFamily="Consolas"
-                 FontSize="14"
-                 Background="#FF1E1E1E"
-                 Foreground="White"
-                 Margin="10"
-                 DockPanel.Dock="Bottom"/>
-    </DockPanel>
+        xmlns:d="https://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:userControls="clr-namespace:OmniMouse.Views.UserControls"
+        mc:Ignorable="d"
+        Title="OmniMouse Input Monitor" Height="500" Width="800" Background="White">
+    <Grid>
+        <userControls:HomePage Loaded="HomePage_Loaded"/>
+    </Grid>
 </Window>

--- a/OmniMouse/MainWindow.xaml.cs
+++ b/OmniMouse/MainWindow.xaml.cs
@@ -6,101 +6,21 @@ namespace OmniMouse
 {
     public partial class MainWindow : Window
     {
-        private InputHooks? _hooks;
-        private UdpMouseTransmitter? _udp;
-        private bool _isSender = false; // true when this machine is sending input
+        //private InputHooks? _hooks;
+        //private UdpMouseTransmitter? _udp;
+        //private bool _isSender = false; // true when this machine is sending input
 
         public MainWindow()
         {
             InitializeComponent();
-            App.ConsoleOutputReceived += OnConsoleOutputReceived;
-            SetUiEnabled(true);
+
         }
 
-        private void SetUiEnabled(bool enabled)
+        private void HomePage_Loaded(object sender, RoutedEventArgs e)
         {
-            HostButton.IsEnabled = enabled;
-            CohostButton.IsEnabled = enabled;
-            HostIpBox.IsEnabled = enabled;
-            DisconnectButton.IsEnabled = !enabled; // Only enable Disconnect when connected
+
         }
 
-        // Host = sender (controls the cohost). Requires the cohost's IP in HostIpBox.
-        private void HostButton_Click(object sender, RoutedEventArgs e)
-        {
-            var ip = HostIpBox.Text.Trim();
-            if (string.IsNullOrWhiteSpace(ip))
-            {
-                Console.WriteLine("Please enter the Cohost's IP address before starting Host mode (Host will send input to that IP).");
-                return;
-            }
-
-            SetUiEnabled(false);
-            Console.WriteLine($"Starting in Host mode (sender). Sending input to {ip}...");
-            _udp = new UdpMouseTransmitter();
-            // StartCoHost configures the transmitter to send to a remote endpoint.
-            _udp.StartCoHost(ip);
-
-            // As Host we must capture local input and send it — install hooks.
-            StartHooks(_udp);
-            _isSender = true;
-        }
-
-        // Cohost = receiver (listens for incoming input and injects it). Does not send.
-        private void CohostButton_Click(object sender, RoutedEventArgs e)
-        {
-            SetUiEnabled(false);
-            Console.WriteLine("Starting in Cohost mode (receiver). Listening for incoming input...");
-            _udp = new UdpMouseTransmitter();
-            // StartHost configures the transmitter to listen on the UDP port and inject on receive.
-            _udp.StartHost();
-
-            // Do NOT install input hooks here — the Cohost should not send its local input.
-            _isSender = false;
-        }
-
-        private void StartHooks(UdpMouseTransmitter udp)
-        {
-            _hooks = new InputHooks(udp);
-            _hooks.InstallHooks();
-
-            // Run the message pump on a background thread
-            var thread = new System.Threading.Thread(_hooks.RunMessagePump)
-            {
-                IsBackground = true
-            };
-            thread.Start();
-        }
-
-        private void OnConsoleOutputReceived(string text)
-        {
-            Dispatcher.Invoke(() =>
-            {
-                ConsoleOutputBox.AppendText(text);
-                ConsoleOutputBox.ScrollToEnd();
-            });
-        }
-
-        protected override void OnClosed(System.EventArgs e)
-        {
-            App.ConsoleOutputReceived -= OnConsoleOutputReceived;
-            if (_isSender)
-            {
-                // If we installed hooks (because we're a sender/Host), uninstall them.
-                _hooks?.UninstallHooks();
-            }
-            base.OnClosed(e);
-        }
-
-        private void DisconnectButton_Click(object sender, RoutedEventArgs e)
-        {
-            Console.WriteLine("Disconnecting session...");
-            _hooks?.UninstallHooks();
-            _udp?.Disconnect();
-            _hooks = null;
-            _udp = null;
-            _isSender = false;
-            SetUiEnabled(true);
-        }
+       
     }
 }

--- a/OmniMouse/Views/UserControls/HomePage.xaml
+++ b/OmniMouse/Views/UserControls/HomePage.xaml
@@ -1,0 +1,30 @@
+﻿<UserControl x:Class="OmniMouse.Views.UserControls.HomePage"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             mc:Ignorable="d"
+             d:DesignHeight="450" d:DesignWidth="625">
+    
+    <DockPanel Background="White">
+        <StackPanel Orientation="Horizontal" Margin="10" DockPanel.Dock="Top">
+            <Button Name="HostButton" Content="Host" Width="100" Margin="0,0,10,0" Click="HostButton_Click"/>
+            <Button Name="CohostButton" Content="Cohost" Width="100" Margin="0,0,10,0" Click="CohostButton_Click"/>
+            <Button Name="DisconnectButton" Content="Disconnect" Width="120" Margin="0,0,10,0" Click="DisconnectButton_Click"/>
+            <TextBox Name="HostIpBox" Width="200" Margin="0,0,10,0" VerticalAlignment="Center" ToolTip="Enter host IP for cohost mode"/>
+        </StackPanel>
+        <TextBlock Text="OmniMouse Input/Output Log" FontWeight="Bold" FontSize="18" Margin="10" DockPanel.Dock="Top"/>
+        <TextBox Name="ConsoleOutputBox"
+                 VerticalScrollBarVisibility="Auto"
+                 HorizontalScrollBarVisibility="Auto"
+                 IsReadOnly="True"
+                 TextWrapping="Wrap"
+                 AcceptsReturn="True"
+                 FontFamily="Consolas"
+                 FontSize="14"
+                 Background="#FF1E1E1E"
+                 Foreground="White"
+                 Margin="10"
+                 DockPanel.Dock="Bottom"/>
+    </DockPanel>
+</UserControl>

--- a/OmniMouse/Views/UserControls/HomePage.xaml.cs
+++ b/OmniMouse/Views/UserControls/HomePage.xaml.cs
@@ -1,0 +1,107 @@
+﻿using OmniMouse.Hooks;
+using OmniMouse.Network;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
+using System.Windows.Documents;
+using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+using System.Windows.Navigation;
+using System.Windows.Shapes;
+
+namespace OmniMouse.Views.UserControls
+{
+    public partial class HomePage : UserControl
+    {
+        private InputHooks? _hooks;
+        private UdpMouseTransmitter? _udp;
+        private bool _isSender = false;
+
+        public HomePage()
+        {
+            InitializeComponent();
+            Loaded += OnLoaded;
+            Unloaded += OnUnloaded;
+        }
+
+        private void OnLoaded(object? s, RoutedEventArgs e)
+        {
+            App.ConsoleOutputReceived += OnConsoleOutputReceived;
+            SetUiEnabled(true);
+        }
+
+        private void OnUnloaded(object? s, RoutedEventArgs e)
+        {
+            App.ConsoleOutputReceived -= OnConsoleOutputReceived;
+            if (_isSender) _hooks?.UninstallHooks();
+            _udp?.Disconnect();
+            _hooks = null; _udp = null; _isSender = false;
+        }
+
+        private void SetUiEnabled(bool enabled)
+        {
+            HostButton.IsEnabled = enabled;
+            CohostButton.IsEnabled = enabled;
+            HostIpBox.IsEnabled = enabled;
+            DisconnectButton.IsEnabled = !enabled;
+        }
+
+        private void HostButton_Click(object sender, RoutedEventArgs e)
+        {
+            var ip = HostIpBox.Text.Trim();
+            if (string.IsNullOrWhiteSpace(ip))
+            {
+                Console.WriteLine("Enter the Cohost's IP before starting Host mode.");
+                return;
+            }
+
+            SetUiEnabled(false);
+            Console.WriteLine($"Starting Host (sender). Sending to {ip}...");
+            _udp = new UdpMouseTransmitter();
+            _udp.StartCoHost(ip);
+            StartHooks(_udp);
+            _isSender = true;
+        }
+
+        private void CohostButton_Click(object sender, RoutedEventArgs e)
+        {
+            SetUiEnabled(false);
+            Console.WriteLine("Starting Cohost (receiver). Listening...");
+            _udp = new UdpMouseTransmitter();
+            _udp.StartHost();
+            _isSender = false;
+        }
+
+        private void StartHooks(UdpMouseTransmitter udp)
+        {
+            _hooks = new InputHooks(udp);
+            _hooks.InstallHooks();
+            var thread = new System.Threading.Thread(_hooks.RunMessagePump) { IsBackground = true };
+            thread.Start();
+        }
+
+        private void OnConsoleOutputReceived(string text)
+        {
+            Dispatcher.Invoke(() =>
+            {
+                ConsoleOutputBox.AppendText(text);
+                ConsoleOutputBox.ScrollToEnd();
+            });
+        }
+
+        private void DisconnectButton_Click(object sender, RoutedEventArgs e)
+        {
+            Console.WriteLine("Disconnecting session...");
+            _hooks?.UninstallHooks();
+            _udp?.Disconnect();
+            _hooks = null; _udp = null; _isSender = false;
+            SetUiEnabled(true);
+        }
+    }
+}

--- a/src/OmniMouse.Core/OmniMouse.Core.csproj
+++ b/src/OmniMouse.Core/OmniMouse.Core.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     <RootNamespace>OmniMouse.Core</RootNamespace>


### PR DESCRIPTION
This PR creates a HomePage user control (Views/UserControls/HomePage.xaml/.cs) and updates MainWindow.xaml to host it, reducing MainWindow clutter and modularizing the UI for easier future changes. Event handlers for Host/Cohost/Disconnect and console output wiring were moved into the control; namespaces were aligned (x:Class="OmniMouse.Views.UserControls.HomePage"), and duplicate <Page>/<Compile> items in the project file were removed to resolve implicit-item conflicts.